### PR TITLE
test27

### DIFF
--- a/testsuite/test27/after.ttl
+++ b/testsuite/test27/after.ttl
@@ -1,0 +1,12 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+
+ex:a a dcat:Catalog ;
+    dcterms:title "Catalog A" ;
+    dcat:dataset ex:b .
+
+ex:b a dcat:Dataset ;
+    dcterms:title "Dataset B Updated Twice" ;
+    dcterms:description "A DCAT-AP dataset with final update." .

--- a/testsuite/test27/before.ttl
+++ b/testsuite/test27/before.ttl
@@ -1,0 +1,12 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+
+ex:a a dcat:Catalog ;
+    dcterms:title "Catalog A" ;
+    dcat:dataset ex:b .
+
+ex:b a dcat:Dataset ;
+    dcterms:title "Dataset B" ;
+    dcterms:description "A DCAT-AP dataset." .

--- a/testsuite/test27/feed.trig
+++ b/testsuite/test27/feed.trig
@@ -1,0 +1,39 @@
+@prefix ldes: <https://w3id.org/ldes#> .
+@prefix tree: <https://w3id.org/tree#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix as: <https://www.w3.org/ns/activitystreams#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://example.com/> .
+
+<#Feed> a ldes:EventStream ;
+    tree:shape <https://semiceu.github.io/LDES-DCAT-AP-feeds/shape.ttl#ActivityShape> ;
+    dcterms:title "Updates that are at the exact same time" ;
+    ldes:timestampPath as:published ;
+    ldes:versionOfPath as:object ;
+    ldes:sequencePath sh:order ;
+    tree:view <> ;
+    tree:member <https://example.com/b#Event2>, <https://example.com/b#Event1> .
+
+<https://example.com/b#Event2> a as:Update ;
+    as:object ex:b ;
+    as:published "2023-10-01T12:00:00Z"^^xsd:dateTime ;
+    sh:order "2"^^xsd:integer .
+
+<https://example.com/b#Event2> {
+    ex:b a dcat:Dataset ;
+        dcterms:title "Dataset B Updated Twice" ;
+        dcterms:description "A DCAT-AP dataset with final update." .
+}
+
+<https://example.com/b#Event1> a as:Update ;
+    as:object ex:b ;
+    as:published "2023-10-01T12:00:00Z"^^xsd:dateTime ;
+    sh:order "1"^^xsd:integer .
+
+<https://example.com/b#Event1> {
+    ex:b a dcat:Dataset ;
+        dcterms:title "Dataset B Updated Once" ;
+        dcterms:description "A DCAT-AP dataset with first update." .
+}

--- a/testsuite/test27/report.json
+++ b/testsuite/test27/report.json
@@ -1,0 +1,11 @@
+{
+  "added": 0,
+  "removed": 0,
+  "updated": 1,
+  "unchanged": 1,
+  "addedURIs": [],
+  "removedURIs": [],
+  "updatedURIs": [
+    "http://example.com/b"
+  ]
+}

--- a/testsuite/test27/test.sparql
+++ b/testsuite/test27/test.sparql
@@ -1,0 +1,11 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ex: <http://example.com/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+ASK {
+  ex:b a dcat:Dataset ;
+    dcterms:title "Dataset B Updated Twice" ;
+    dcterms:description "A DCAT-AP dataset with final update." .
+}


### PR DESCRIPTION
# Pull Request Description

This adds the 27th test.

As the prefered property to use for setting the sequence of same time events hasn't been set (see https://github.com/SEMICeu/LDES-DCAT-AP-feeds/issues/19 ) `sh:order` used in the feed should not yet be considered a stable choice. This also means that the feed will not validate against the `dcatapfeeds` shape file.

The events have purposefully been put in inverted order in the file to ensure `ldes:sequencePath` rather than order of appearance was used.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
