### PR TITLE
Split reporting per stand-alone entity type

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -28,15 +28,25 @@ const executeSPARQLTest = async (testSuite, testPath) => {
 const executeReportTest = async (testSuite, testPath) => {
   const reportSuite = JSON.parse(fs.readFileSync(`${testSuite}/report.json`, { encoding: 'utf8' }));
   const reportPath = JSON.parse(fs.readFileSync(`${testPath}/report.json`, { encoding: 'utf8' }));
-  expect(reportSuite.added).toBe(reportPath.added);
-  expect(reportSuite.removed).toBe(reportPath.removed);
-  expect(reportSuite.updated).toBe(reportPath.updated);
-  expect(reportSuite.addedURIs.length).toBe(reportPath.addedURIs.length);
-  expect(reportSuite.removedURIs.length).toBe(reportPath.removedURIs.length);
-  expect(reportSuite.updatedURIs.length).toBe(reportPath.updatedURIs.length);
-  expect(reportSuite.addedURIs).toEqual(expect.arrayContaining(reportPath.addedURIs));
-  expect(reportSuite.removedURIs).toEqual(expect.arrayContaining(reportPath.removedURIs));
-  expect(reportSuite.updatedURIs).toEqual(expect.arrayContaining(reportPath.updatedURIs));
+
+  // Get all entity types from both reports
+  const entityTypes = new Set([...Object.keys(reportSuite), ...Object.keys(reportPath)]);
+  const defaults = { added: 0, removed: 0, updated: 0, unchanged: 0, addedURIs: [], removedURIs: [], updatedURIs: [] };
+
+  for (const entityType of entityTypes) {
+    const suiteCounts = reportSuite[entityType] || { ...defaults };
+    const pathCounts = reportPath[entityType] || { ...defaults };
+
+    expect(suiteCounts.added).toBe(pathCounts.added);
+    expect(suiteCounts.removed).toBe(pathCounts.removed);
+    expect(suiteCounts.updated).toBe(pathCounts.updated);
+    expect(suiteCounts.addedURIs.length).toBe(pathCounts.addedURIs.length);
+    expect(suiteCounts.removedURIs.length).toBe(pathCounts.removedURIs.length);
+    expect(suiteCounts.updatedURIs.length).toBe(pathCounts.updatedURIs.length);
+    expect(suiteCounts.addedURIs).toEqual(expect.arrayContaining(pathCounts.addedURIs));
+    expect(suiteCounts.removedURIs).toEqual(expect.arrayContaining(pathCounts.removedURIs));
+    expect(suiteCounts.updatedURIs).toEqual(expect.arrayContaining(pathCounts.updatedURIs));
+  }
 };
 
 export const runTests = async (testSuite, testPath) => {

--- a/testsuite/test1/report.json
+++ b/testsuite/test1/report.json
@@ -1,11 +1,22 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 0,
-  "unchanged": 1,
-  "addedURIs": [
-    "http://example.com/a"
-  ],
-  "removedURIs": [],
-  "updatedURIs": []
+  "dcat:Catalog": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/a"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test10/report.json
+++ b/testsuite/test10/report.json
@@ -1,13 +1,42 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 2,
-  "addedURIs": [
-    "http://example.com/c"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:DataService": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/c"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test11/report.json
+++ b/testsuite/test11/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [
-    "http://example.com/c"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:DataService": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/c"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test12/report.json
+++ b/testsuite/test12/report.json
@@ -1,11 +1,22 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/c"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:DataService": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/c"
+    ]
+  }
 }

--- a/testsuite/test13/report.json
+++ b/testsuite/test13/report.json
@@ -1,11 +1,22 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/c"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:DataService": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/c"
+    ]
+  }
 }

--- a/testsuite/test14/report.json
+++ b/testsuite/test14/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 0,
-  "removed": 1,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [
-    "http://example.com/c"
-  ],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:DataService": {
+    "added": 0,
+    "removed": 1,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [
+      "http://example.com/c"
+    ],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test15/report.json
+++ b/testsuite/test15/report.json
@@ -1,14 +1,44 @@
 {
-  "added": 0,
-  "removed": 1,
-  "updated": 2,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [
-    "http://example.com/b"
-  ],
-  "updatedURIs": [
-    "http://example.com/a",
-    "http://example.com/c"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 1,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [
+      "http://example.com/b"
+    ],
+    "updatedURIs": []
+  },
+  "dcat:DataService": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/c"
+    ]
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test16/report.json
+++ b/testsuite/test16/report.json
@@ -1,13 +1,42 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 2,
-  "addedURIs": [
-    "http://example.com/d"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/b"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/b"
+    ]
+  },
+  "dcat:Distribution": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/d"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:DataService": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test17/report.json
+++ b/testsuite/test17/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [
-    "http://example.com/d"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/b"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/b"
+    ]
+  },
+  "dcat:Distribution": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/d"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test18/report.json
+++ b/testsuite/test18/report.json
@@ -1,11 +1,40 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 3,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/d"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Distribution": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/d"
+    ]
+  },
+  "dcat:DataService": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test19/report.json
+++ b/testsuite/test19/report.json
@@ -1,11 +1,31 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 2,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/d"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Distribution": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/d"
+    ]
+  }
 }

--- a/testsuite/test2/report.json
+++ b/testsuite/test2/report.json
@@ -1,11 +1,22 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test20/report.json
+++ b/testsuite/test20/report.json
@@ -1,11 +1,13 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 0,
-  "unchanged": 0,
-  "addedURIs": [
-    "http://example.com/cp"
-  ],
-  "removedURIs": [],
-  "updatedURIs": []
+  "vcard:Kind": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/cp"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test21/report.json
+++ b/testsuite/test21/report.json
@@ -1,11 +1,13 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 0,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/cp"
-  ]
+  "vcard:Kind": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/cp"
+    ]
+  }
 }

--- a/testsuite/test22/report.json
+++ b/testsuite/test22/report.json
@@ -1,11 +1,13 @@
 {
-  "added": 0,
-  "removed": 1,
-  "updated": 0,
-  "unchanged": 0,
-  "addedURIs": [],
-  "removedURIs": [
-    "http://example.com/cp"
-  ],
-  "updatedURIs": []
+  "vcard:Kind": {
+    "added": 0,
+    "removed": 1,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [
+      "http://example.com/cp"
+    ],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test23/report.json
+++ b/testsuite/test23/report.json
@@ -1,11 +1,13 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 0,
-  "unchanged": 0,
-  "addedURIs": [
-    "http://example.com/pub"
-  ],
-  "removedURIs": [],
-  "updatedURIs": []
+  "foaf:Agent": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/pub"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test24/report.json
+++ b/testsuite/test24/report.json
@@ -1,11 +1,13 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 0,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/pub"
-  ]
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/pub"
+    ]
+  }
 }

--- a/testsuite/test25/report.json
+++ b/testsuite/test25/report.json
@@ -1,11 +1,13 @@
 {
-  "added": 0,
-  "removed": 1,
-  "updated": 0,
-  "unchanged": 0,
-  "addedURIs": [],
-  "removedURIs": [
-    "http://example.com/pub"
-  ],
-  "updatedURIs": []
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 1,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [
+      "http://example.com/pub"
+    ],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test26/report.json
+++ b/testsuite/test26/report.json
@@ -1,11 +1,31 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 2,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/b"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/b"
+    ]
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test3/report.json
+++ b/testsuite/test3/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [
-    "http://example.com/b"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:Dataset": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/b"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test4/report.json
+++ b/testsuite/test4/report.json
@@ -1,11 +1,22 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/b"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/b"
+    ]
+  }
 }

--- a/testsuite/test5/report.json
+++ b/testsuite/test5/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 0,
-  "removed": 1,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [
-    "http://example.com/b"
-  ],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 1,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [
+      "http://example.com/b"
+    ],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test6/report.json
+++ b/testsuite/test6/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [
-    "http://example.com/c"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/b"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/b"
+    ]
+  },
+  "dcat:Distribution": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/c"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test7/report.json
+++ b/testsuite/test7/report.json
@@ -1,11 +1,31 @@
 {
-  "added": 0,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 2,
-  "addedURIs": [],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/c"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Distribution": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/c"
+    ]
+  }
 }

--- a/testsuite/test8/report.json
+++ b/testsuite/test8/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 0,
-  "removed": 1,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [],
-  "removedURIs": [
-    "http://example.com/c"
-  ],
-  "updatedURIs": [
-    "http://example.com/b"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "dcat:Dataset": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/b"
+    ]
+  },
+  "dcat:Distribution": {
+    "added": 0,
+    "removed": 1,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [
+      "http://example.com/c"
+    ],
+    "updatedURIs": []
+  }
 }

--- a/testsuite/test9/report.json
+++ b/testsuite/test9/report.json
@@ -1,13 +1,33 @@
 {
-  "added": 1,
-  "removed": 0,
-  "updated": 1,
-  "unchanged": 1,
-  "addedURIs": [
-    "http://example.com/c"
-  ],
-  "removedURIs": [],
-  "updatedURIs": [
-    "http://example.com/a"
-  ]
+  "dcat:Catalog": {
+    "added": 0,
+    "removed": 0,
+    "updated": 1,
+    "unchanged": 0,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": [
+      "http://example.com/a"
+    ]
+  },
+  "dcat:DataService": {
+    "added": 1,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 0,
+    "addedURIs": [
+      "http://example.com/c"
+    ],
+    "removedURIs": [],
+    "updatedURIs": []
+  },
+  "foaf:Agent": {
+    "added": 0,
+    "removed": 0,
+    "updated": 0,
+    "unchanged": 1,
+    "addedURIs": [],
+    "removedURIs": [],
+    "updatedURIs": []
+  }
 }


### PR DESCRIPTION
# Pull Request Description

Split reporting per stand-alone entity type

Addresses #5 (does not fix it as only the first out of the 4 suggestions is addressed)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
